### PR TITLE
auto.js中参数错误导致无法正常运行

### DIFF
--- a/auto.js
+++ b/auto.js
@@ -81,13 +81,13 @@ async.auto({
             callback(null, 'myfolder');
         }, 200);
     },
-    writeFile: ['getData', 'makeFolder', function(callback, results) {
+    writeFile: ['getData', 'makeFolder', function(results, callback) {
         setTimeout(function(){
             console.log('1.2: wrote file');
             callback('myerr');
         }, 300);
     }],
-    emailFiles: ['writeFile', function(callback, results) {
+    emailFiles: ['writeFile', function(results, callback) {
         console.log('1.2: emailed file: ' + results.writeFile);
         callback('err sending email', results.writeFile);
     }]


### PR DESCRIPTION
auto.js中。writeFile和emailFiles函数返回参数第一个是resutlts，第二个才是callback，示例中刚好相反，会导致该示例无法正常运行。